### PR TITLE
Disable coffeelint linelength check for ievm curl command

### DIFF
--- a/src/ievm.coffee
+++ b/src/ievm.coffee
@@ -54,6 +54,7 @@ class IEVM
 
   # The command used to install virtual machines via ievms.
   @ievmsCmd: process.env.IEVMS_CMD ?
+    # coffeelint: disable=max_line_length
     'curl -s https://raw.githubusercontent.com/xdissent/ievms/master/ievms.sh | bash'
 
   # The host IP as seen by the VM.


### PR DESCRIPTION
coffee lint was failing due to the line length of the ievm curl command:

```
> iectrl@0.0.4 test /Users/nicktomlin/workspace/fork-iectrl
> coffeelint -r src && mocha

  ✓ src/cli.coffee
  ✓ src/commands/clean.coffee
  ✓ src/commands/close.coffee
  ✓ src/commands/install.coffee
  ✓ src/commands/nuke.coffee
  ✓ src/commands/open.coffee
  ✓ src/commands/rearm.coffee
  ✓ src/commands/reinstall.coffee
  ✓ src/commands/restart.coffee
  ✓ src/commands/screenshot.coffee
  ✓ src/commands/shrink.coffee
  ✓ src/commands/start.coffee
  ✓ src/commands/status.coffee
  ✓ src/commands/stop.coffee
  ✓ src/commands/uninstall.coffee
  ✓ src/commands/uploaded.coffee
  ✗ src/ievm.coffee
     ✗ #57: Line exceeds maximum allowed length. Length is 85, max is 80.
  ✓ src/index.coffee

✗ Lint! » 1 error and 0 warnings in 18 files
```

Output after change:

```
git:coffeelint-errors ᎒ git branch
* coffeelint-errors
  master
[~/workspace/fork-iectrl]
git:coffeelint-errors ᎒ npm test

> iectrl@0.0.4 test /Users/nicktomlin/workspace/fork-iectrl
> coffeelint -r src && mocha

  ✓ src/cli.coffee
  ✓ src/commands/clean.coffee
  ✓ src/commands/close.coffee
  ✓ src/commands/install.coffee
  ✓ src/commands/nuke.coffee
  ✓ src/commands/open.coffee
  ✓ src/commands/rearm.coffee
  ✓ src/commands/reinstall.coffee
  ✓ src/commands/restart.coffee
  ✓ src/commands/screenshot.coffee
  ✓ src/commands/shrink.coffee
  ✓ src/commands/start.coffee
  ✓ src/commands/status.coffee
  ✓ src/commands/stop.coffee
  ✓ src/commands/uninstall.coffee
  ✓ src/commands/uploaded.coffee
  ✓ src/ievm.coffee
  ✓ src/index.coffee

✓ Ok! » 0 errors and 0 warnings in 18 files
```
