### PR TITLE
Adds command to list currently installed virtual machines

### DIFF
--- a/src/commands/list.coffee
+++ b/src/commands/list.coffee
@@ -1,0 +1,13 @@
+cli = require '../cli'
+colors = require 'colors'
+
+module.exports = (program) -> program
+  .command('list')
+  .description('list available virtual machines')
+  .action (names, command) ->
+    cli.find(null, '!missing').then (vms) ->
+      heading = "Available virtual machines:\n".green
+      message = vms.reduce (string, vm) ->
+        string + "\n#{vm.name.blue}"
+      , heading
+      console.log(message)

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -15,6 +15,7 @@ subcommands = [
   'close'
   'install'
   'nuke'
+  'list'
   'open'
   'rearm'
   'reinstall'


### PR DESCRIPTION
``` bash
$ iectrl
  Commands:
    # ...
    nuke [names] remove all traces of virtual machines
    list         list available virtual machines
    open [options] [names] [url] open a URL in IE
    # ...

$ iectrl list
Available virtual machines:

IE8 - Win7
IE9 - Win7
IE10 - Win7
IE11 - Win7
```

I personally find this useful, since I switch between machines that may or may not have the same set of IEVMS installed. Please critique/reject as needed :)
