### PR TITLE
Fix virtualbox guest control exec arguments

### DIFF
--- a/src/ievm.coffee
+++ b/src/ievm.coffee
@@ -279,8 +279,8 @@ class IEVM
         pass = ['--password', 'Passw0rd!']
         pass = [] if @os is 'WinXP' and !version?
         args = [
-          'run', '--exe', cmd,
           '--username', 'IEUser', pass...,
+          'run', cmd, '--',
           args...
         ]
         @vbm 'guestcontrol', args...


### PR DESCRIPTION
I had problem with executing any command after clean installation. Initialization process always stopped with `ping` command. My setup:

* Mac OS X 10.10.4
* VirtualBox 5.0.2 r102096
* Any IE vms (I tried with EDGE and 11)

In my case this is caused by wrong arguments in `exec` method. I checked help of virtualbox command and changed it.

I can't check it if my commit will work with other versions.  If this is case for you, please merge pull request. Library uses built sources published to npm, so using fork of it through github is not convenient. 

