### PR TITLE
Fix #28 #29

### DIFF
--- a/src/ievm.coffee
+++ b/src/ievm.coffee
@@ -279,9 +279,9 @@ class IEVM
         pass = ['--password', 'Passw0rd!']
         pass = [] if @os is 'WinXP' and !version?
         args = [
+          'exec', '--image', cmd,
           '--username', 'IEUser', pass...,
-          'run', cmd, '--',
-          args...
+          '--', args...
         ]
         @vbm 'guestcontrol', args...
 


### PR DESCRIPTION
It seems that newer versions of `VBoxManage` now have a new order to the command line arguments.